### PR TITLE
repaired a malformed <th> tag in inspect.rb

### DIFF
--- a/actions/inspect.rb
+++ b/actions/inspect.rb
@@ -31,7 +31,7 @@ class ActionInspect
     end
 
     if @host.siblings.length > 0
-      html += "<tr><th>Inventory<td>"
+      html += "<tr><th>Inventory</th><td>"
       @host.siblings.each do |vessel|
         html += "<action data-action='enter the #{vessel.name}'>#{vessel.attr} #{vessel.name} ≡#{vessel.id}</action></br />"
       end


### PR DESCRIPTION
The '\<th\>'-tag has not been closed in the 'Inventory' section of the table.
Gave me some trouble when I tried to parse the html.