### PR TITLE
A couple bugs in Paradise

### DIFF
--- a/vessels/teapot.rb
+++ b/vessels/teapot.rb
@@ -47,7 +47,7 @@ class Teapot
 
     @path = File.expand_path(File.join(File.dirname(__FILE__), "/"))
     @docs = "Default Paradise vessel."
-    
+
     install(:generic,:look)
     install(:generic,:help)
     install(:generic,:inspect)
@@ -108,9 +108,9 @@ class Teapot
 
   end
 
-  def to_s 
+  def to_s
 
-    return "#{attr ? attr+' ' : ''}#{name}"    
+    return "#{attr ? attr+' ' : ''}#{name}"
 
   end
 
@@ -204,7 +204,7 @@ class Teapot
     @creator = @creator ? @creator : $nataniev.vessels[:paradise].corpse.parade[owner]
 
     return @creator ? @creator : VesselVoid.new
-    
+
   end
 
   def tunnels
@@ -240,7 +240,7 @@ class Teapot
 
     if @children then return @children end
     if !$nataniev.vessels[:paradise].corpse.parade then return [] end
-      
+
     @children = []
     $nataniev.vessels[:paradise].corpse.parade.each do |vessel|
       if vessel.unde != @id then next end
@@ -408,19 +408,19 @@ class Teapot
   def has_note
 
     return @note.to_s.strip != "" ? true : false
-    
+
   end
 
   def has_attr
 
     return @attr.to_s != "" ? true : false
-    
+
   end
 
   def has_program
 
     return program.is_valid
-    
+
   end
 
   def has_children
@@ -510,7 +510,7 @@ class Teapot
     end
 
     return ((sum/values.length.to_f) * 100).to_i
-    
+
   end
 
 end

--- a/vessels/teapot.rb
+++ b/vessels/teapot.rb
@@ -153,6 +153,18 @@ class Teapot
 
   def parent
 
+    # Sometimes corpse and parade are nil (wut?)
+    # My working theory is that as other http requests hit invoke.rb, the
+    # corpse and parade variables are getting reassigned and when this tries
+    # to access them while they are being reassigned, nil is returned.
+    # Waiting a bit if they are nil seems to fix the bug...
+    it = 0
+    while it < 10 && ($nataniev.vessels[:paradise].corpse.nil? || $nataniev.vessels[:paradise].corpse.parade.nil?)
+      puts "Searching for parents..."
+      slep 0.5
+      it += 1
+    end
+
     @parent = @parent ? @parent : $nataniev.vessels[:paradise].corpse.parade[@unde]
 
     return @parent ? (@parent.id = @unde ; @parent) : VesselVoid.new

--- a/vessels/teapot.rb
+++ b/vessels/teapot.rb
@@ -161,7 +161,7 @@ class Teapot
     it = 0
     while it < 10 && ($nataniev.vessels[:paradise].corpse.nil? || $nataniev.vessels[:paradise].corpse.parade.nil?)
       puts "Searching for parents..."
-      slep 0.5
+      sleep 0.5
       it += 1
     end
 

--- a/vessels/void.rb
+++ b/vessels/void.rb
@@ -4,13 +4,13 @@
 class VesselVoid
 
   include Vessel
-  include VesselToolkit
+  # include VesselToolkit
 
   attr_accessor :unde
   attr_accessor :note
   attr_accessor :parent
   attr_accessor :owner
-  
+
   attr_accessor :is_locked
   attr_accessor :is_hidden
   attr_accessor :is_silent


### PR DESCRIPTION
Noticed that paradise was throwing a bug on the Void vessel, and when I fixed that, I was getting the strangest bug randomly when navigating to paradise without a vessel ID; looked like $nataniev.vessels[:paradise].corpse.parade and sometimes even $nataniev.vessels[:paradise].corpse were nil. Refreshing seemed to make the error go away.

I noticed this both locally and at paradise.xxiivv.com.

After much inconclusive digging, this seems to fix stuff.