### PR TITLE
The continued case of the missing corpse and parade...

### DIFF
--- a/objects/comment.rb
+++ b/objects/comment.rb
@@ -52,6 +52,8 @@ class Comment
 
   def vessel_name
 
+    await_parade("comment")
+
     if !$nataniev.vessels[:paradise].corpse.parade[from] then return "ghost" end
 
     vessel = $nataniev.vessels[:paradise].corpse.parade[from]
@@ -136,5 +138,25 @@ class Comment
     return false
 
   end
-  
+
+  def await_parade
+
+    it = 0
+    while it < 10 && (defined?($nataniev.vessels[:paradise].corpse) == nil || $nataniev.vessels[:paradise].corpse.nil?)
+      puts "Searching for corpse..."
+      sleep 0.5
+      it += 1
+    end
+
+    it = 0
+    while it < 10 && (defined?($nataniev.vessels[:paradise].corpse.parade) == nil || $nataniev.vessels[:paradise].corpse.parade.nil?)
+      puts "Searching for parade..."
+      sleep 0.5
+      it += 1
+    end
+
+    return
+
+  end
+
 end

--- a/objects/comment.rb
+++ b/objects/comment.rb
@@ -52,7 +52,7 @@ class Comment
 
   def vessel_name
 
-    await_parade("comment")
+    await_parade
 
     if !$nataniev.vessels[:paradise].corpse.parade[from] then return "ghost" end
 

--- a/objects/comment.rb
+++ b/objects/comment.rb
@@ -2,19 +2,19 @@
 # encoding: utf-8
 
 class Comment
-  
+
   attr_accessor :id
-  
+
   def initialize content = {}
-    
+
     @content = content
-    
+
   end
-  
+
   def timestamp
-    
+
     return Timestamp.new(@content['TIMESTAMP'])
-    
+
   end
 
   def inject host,message

--- a/vessels/teapot.rb
+++ b/vessels/teapot.rb
@@ -153,17 +153,7 @@ class Teapot
 
   def parent
 
-    # Sometimes corpse and parade are nil (wut?)
-    # My working theory is that as other http requests hit invoke.rb, the
-    # corpse and parade variables are getting reassigned and when this tries
-    # to access them while they are being reassigned, nil is returned.
-    # Waiting a bit if they are nil seems to fix the bug...
-    it = 0
-    while it < 10 && ($nataniev.vessels[:paradise].corpse.nil? || $nataniev.vessels[:paradise].corpse.parade.nil?)
-      puts "Searching for parents..."
-      sleep 0.5
-      it += 1
-    end
+    await_parade("parent")
 
     @parent = @parent ? @parent : $nataniev.vessels[:paradise].corpse.parade[@unde]
 
@@ -235,6 +225,8 @@ class Teapot
   def siblings
 
     if @siblings then return @siblings end
+
+    await_parade("siblings")
 
     @siblings = []
     $nataniev.vessels[:paradise].corpse.parade.each do |vessel|
@@ -522,6 +514,31 @@ class Teapot
     end
 
     return ((sum/values.length.to_f) * 100).to_i
+
+  end
+
+  def await_parade
+
+    # Sometimes corpse and parade are nil (wut?)
+    # My working theory is that as other http requests hit invoke.rb, the
+    # corpse and parade variables are getting reassigned and when this tries
+    # to access them while they are being reassigned, nil is returned.
+    # Waiting a bit if they are nil seems to fix the bug...
+    it = 0
+    while it < 10 && (defined?($nataniev.vessels[:paradise].corpse) == nil || $nataniev.vessels[:paradise].corpse.nil?)
+      puts "Searching for corpse..."
+      sleep 0.5
+      it += 1
+    end
+
+    it = 0
+    while it < 10 && (defined?($nataniev.vessels[:paradise].corpse.parade) == nil || $nataniev.vessels[:paradise].corpse.parade.nil?)
+      puts "Searching for parade..."
+      sleep 0.5
+      it += 1
+    end
+
+    return
 
   end
 

--- a/vessels/teapot.rb
+++ b/vessels/teapot.rb
@@ -153,7 +153,7 @@ class Teapot
 
   def parent
 
-    await_parade("parent")
+    await_parade
 
     @parent = @parent ? @parent : $nataniev.vessels[:paradise].corpse.parade[@unde]
 
@@ -226,7 +226,7 @@ class Teapot
 
     if @siblings then return @siblings end
 
-    await_parade("siblings")
+    await_parade
 
     @siblings = []
     $nataniev.vessels[:paradise].corpse.parade.each do |vessel|


### PR DESCRIPTION
Noticed a couple other places where suddenly the parade (and EXTREMELY rarely, the corpse!) were randomly nil. Abstracted the fix into a function that can just be inserted into the places it was happening.

More weirdness...`defined?($nataniev.vessels[:paradise].corpse.parade) == nil` would return false, but `$nataniev.vessels[:paradise].corpse.parade.nil?` would return true...

...like seriously are you even kidding me Ruby.

Anyways, this seems to take care of everything I was seeing! Happy sailing to New Zealand :)